### PR TITLE
Change the cluster default to redis 5, not 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ module "example_team_ec_cluster" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| engine_version | Redis ElastiCache engine version | string | `4.0.10` | no |
-| parameter_group_name | ElastiCache engine parameter group name| string | `default.redis4.0` | no |
+| engine_version | Redis ElastiCache engine version | string | `5.0.6` | no |
+| parameter_group_name | ElastiCache engine parameter group name| string | `default.redis5.0` | no |
 | node_type | The instance type of the EC cluster | string | `cache.m3.medium` | no |
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string | - | yes |
 | cluster_state_bucket | The name of the S3 bucket holding the terraform state for the cluster | string | - | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -29,15 +29,15 @@ variable "infrastructure-support" {
 }
 
 variable "engine_version" {
-  description = "The engine version that your ElastiCache Cluster will use. This will differ between the use of 'redis' or 'memcached'. The default is '4.0.10' with redis being the assumed engine."
+  description = "The engine version that your ElastiCache Cluster will use. This will differ between the use of 'redis' or 'memcached'. The default is '5.0.6' with redis being the assumed engine."
   type        = string
-  default     = "4.0.10"
+  default     = "5.0.6"
 }
 
 variable "parameter_group_name" {
-  description = "Name of the parameter group to associate with this cache cluster. Again this will differ between the use of 'redis' or 'memcached' and your engine version. The default is 'default.redis4.0'."
+  description = "Name of the parameter group to associate with this cache cluster. Again this will differ between the use of 'redis' or 'memcached' and your engine version. The default is 'default.redis5.0'."
   type        = string
-  default     = "default.redis4.0"
+  default     = "default.redis5.0"
 }
 
 variable "number_cache_clusters" {


### PR DESCRIPTION
AWS now offer redis 5.0.6 as the basis for elasticache clusters. This
change makes this our default, for new clusters.