### PR TITLE
Replacing remote state with data resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ module "example_team_ec_cluster" {
 
   // The first two inputs are provided by the pipeline for cloud-platform. See the example for more detail.
   cluster_name           = var.cluster_name
-  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "example-repo"
   business-unit          = "example-bu"
   application            = "exampleapp"
@@ -34,9 +33,7 @@ module "example_team_ec_cluster" {
 | parameter_group_name | ElastiCache engine parameter group name| string | `default.redis5.0` | no |
 | node_type | The instance type of the EC cluster | string | `cache.m3.medium` | no |
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string | - | yes |
-| cluster_state_bucket | The name of the S3 bucket holding the terraform state for the cluster | string | - | yes |
 | providers |  providers to use (including region) | string | - | -
-
 
 
 ### Tags

--- a/example/elasticache.tf
+++ b/example/elasticache.tf
@@ -7,9 +7,6 @@
 variable "cluster_name" {
 }
 
-variable "cluster_state_bucket" {
-}
-
 /*
  * Make sure that you use the latest version of the module by changing the
  * `ref=` value in the `source` attribute to the latest version listed on the
@@ -19,7 +16,6 @@ variable "cluster_state_bucket" {
 module "example_team_ec_cluster" {
   source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=4.0"
   cluster_name           = var.cluster_name
-  cluster_state_bucket   = var.cluster_state_bucket
   team_name              = "example-repo"
   namespace              = var.namespace
   business-unit          = "example-bu"


### PR DESCRIPTION
Tested with `contact-moj-development` namespace and no changes (expected)

```
kubernetes_secret.contact_moj_elasticache_redis: Refreshing state... [id=contact-moj-development/contact-moj-elasticache-redis-output]
kubernetes_secret.contact-moj_rds: Refreshing state... [id=contact-moj-development/contact-moj-rds-output]

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.

```