### PR TITLE
Allow maintenance window to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,3 @@ Then you can use the ruby redis client like this:
 ```
 ruby -r redis -e 'redis = Redis.new(uri: ENV.fetch("REDIS_URL")); redis.set("foo", 123); puts redis.get("foo")'
 ```
-

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module "example_team_ec_cluster" {
 | node_type | The instance type of the EC cluster | string | `cache.m3.medium` | no |
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string | - | yes |
 | providers |  providers to use (including region) | string | - | -
-
+| maintenance_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`. | `string` | `""` | no |
 
 ### Tags
 

--- a/main.tf
+++ b/main.tf
@@ -45,14 +45,14 @@ resource "aws_security_group" "ec" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block] 
+    cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block]
   }
 
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block] 
+    cidr_blocks = [for s in data.aws_subnet.private : s.cidr_block]
   }
 }
 
@@ -93,4 +93,3 @@ resource "aws_elasticache_subnet_group" "ec_subnet" {
   name       = "ec-sg-${random_id.id.hex}"
   subnet_ids = data.aws_subnet_ids.private.ids
 }
-

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "aws_elasticache_replication_group" "ec_redis" {
   transit_encryption_enabled    = true
   auth_token                    = random_id.auth_token.hex
   apply_immediately             = true
+  maintenance_window            = var.maintenance_window
 
   tags = {
     namespace              = var.namespace

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,8 @@ variable "node_type" {
   default     = "cache.t2.medium"
 }
 
+variable "maintenance_window" {
+  type        = string
+  description = "Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`."
+  default     = ""
+}


### PR DESCRIPTION
We'd like to make our maintenance window more explicit so it matches the time when we have the least number of users of our tool. This change allows the window to be set.

See [Amazon ElastiCache Managed Maintenance and Service Updates Help Page](https://aws.amazon.com/elasticache/elasticache-maintenance/) for more information.