### PR TITLE
Allow snapshot window to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ module "example_team_ec_cluster" {
 | node_type | The instance type of the EC cluster | string | `cache.m3.medium` | no |
 | cluster_name | The name of the cluster (eg.: cloud-platform-live-0) | string | - | yes |
 | providers |  providers to use (including region) | string | - | -
+| snapshot_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period. Example: `05:00-09:00` | `string` | `""` | no |
 | maintenance_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`. | `string` | `""` | no |
 
 ### Tags

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "aws_elasticache_replication_group" "ec_redis" {
   transit_encryption_enabled    = true
   auth_token                    = random_id.auth_token.hex
   apply_immediately             = true
+  snapshot_window               = var.snapshot_window
   maintenance_window            = var.maintenance_window
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "node_type" {
   default     = "cache.t2.medium"
 }
 
+variable "snapshot_window" {
+  type        = string
+  description = "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period. Example: 05:00-09:00"
+  default     = ""
+}
+
 variable "maintenance_window" {
   type        = string
   description = "Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`."


### PR DESCRIPTION
In https://github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster/pull/25 we added support for setting the maintenance window, but sometimes this conflicts with the snapshot window. This PR makes it possible to also customise the snapshot window to ensure it doesn't conflict.