### PR TITLE
Remove unused `aws_region` and `aws_caller_identity` data calls

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
 data "aws_availability_zones" "available" {
   state = "available"
 }


### PR DESCRIPTION
This PR removes the unused `aws_region` and `aws_caller_identity` data calls within this module (saving two API calls when the module is used).