### PR TITLE
Give providers minimum versions; run terraform fmt; add missing var types

### DIFF
--- a/example/elasticache.tf
+++ b/example/elasticache.tf
@@ -15,7 +15,7 @@ variable "cluster_name" {
  */
 module "example_team_ec_cluster" {
   # always check the latest release in Github and set below
-  source                 = "../"
+  source = "../"
   # source                 = "github.com/ministryofjustice/cloud-platform-terraform-elasticache-cluster?ref=5.2"
   cluster_name           = var.cluster_name
   team_name              = "example-repo"

--- a/main.tf
+++ b/main.tf
@@ -37,10 +37,10 @@ resource "aws_security_group" "ec" {
   description = "Allow inbound traffic from kubernetes private subnets"
   vpc_id      = data.aws_vpc.selected.id
 
-  // We cannot use `${aws_db_instance.rds.port}` here because it creates a
-  // cyclic dependency. Rather than resorting to `aws_security_group_rule` which
-  // is not ideal for managing rules, we will simply allow traffic to all ports.
-  // This does not compromise security as the instance only listens on one port.
+  # We cannot use `${aws_db_instance.rds.port}` here because it creates a
+  # cyclic dependency. Rather than resorting to `aws_security_group_rule` which
+  # is not ideal for managing rules, we will simply allow traffic to all ports.
+  # This does not compromise security as the instance only listens on one port.
   ingress {
     from_port   = 0
     to_port     = 0

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,4 +12,3 @@ output "auth_token" {
   description = "The password used to access the Redis protected server."
   value       = aws_elasticache_replication_group.ec_redis.auth_token
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,30 +1,43 @@
 variable "cluster_name" {
   description = "The name of the cluster (eg.: cloud-platform-live-0)"
+  type        = string
 }
 
 variable "team_name" {
+  description = "The name of your development team"
+  type        = string
 }
 
 variable "application" {
+  description = "The name of your application"
+  type        = string
 }
 
 variable "environment-name" {
+  description = "The name of your environment"
+  type        = string
 }
 
 variable "is-production" {
-  default = "false"
+  description = "Whether this is a production ElastiCache cluster"
+  default     = "false"
+  type        = string
 }
 
 variable "namespace" {
+  description = "The name of your namespace"
+  type        = string
 }
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service"
   default     = "mojdigital"
+  type        = string
 }
 
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
+  type        = string
 }
 
 variable "engine_version" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,14 @@
 terraform {
+  required_version = ">= 0.14"
+
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
     }
   }
-  required_version = ">= 0.13"
 }


### PR DESCRIPTION
This PR does the following:

- runs terraform fmt
- adds missing variable types and missing variable descriptions
- gives defined providers a minimum version
- changes comments to use the # standard rather than the // standard
