### PR TITLE
Add auth_token_rotated_date for token rotation, create iam access

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application"></a> [application](#input\_application) | The name of your application | `string` | n/a | yes |
+| <a name="input_auth_token_rotated_date"></a> [auth\_token\_rotated\_date](#input\_auth\_token\_rotated\_date) | Process to spin new auth token. Pass date to regenerate new token | `string` | `""` | no |
 | <a name="input_business-unit"></a> [business-unit](#input\_business-unit) | Area of the MOJ responsible for the service | `string` | `"mojdigital"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version that your ElastiCache Cluster will use. This will differ between the use of 'redis' or 'memcached'. The default is '5.0.6' with redis being the assumed engine. | `string` | `"5.0.6"` | no |
 | <a name="input_environment-name"></a> [environment-name](#input\_environment-name) | The name of your environment | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ No modules.
 |------|------|
 | [aws_elasticache_replication_group.ec_redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
 | [aws_elasticache_subnet_group.ec_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
+| [aws_iam_access_key.key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
+| [aws_iam_user.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy.userpol](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_security_group.ec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [random_id.auth_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -84,9 +88,12 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_access_key_id"></a> [access\_key\_id](#output\_access\_key\_id) | Access key id for elasticache |
 | <a name="output_auth_token"></a> [auth\_token](#output\_auth\_token) | The password used to access the Redis protected server. |
 | <a name="output_member_clusters"></a> [member\_clusters](#output\_member\_clusters) | The identifiers of all the nodes that are part of this replication group. |
 | <a name="output_primary_endpoint_address"></a> [primary\_endpoint\_address](#output\_primary\_endpoint\_address) | The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled. |
+| <a name="output_replication_group_id"></a> [replication\_group\_id](#output\_replication\_group\_id) | Redis cluster ID |
+| <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | Secret key for elasticache |
 <!-- END_TF_DOCS -->
 
 ## Tags

--- a/example/elasticache.tf
+++ b/example/elasticache.tf
@@ -41,6 +41,8 @@ resource "kubernetes_secret" "example_team_ec_cluster" {
     primary_endpoint_address = module.example_team_ec_cluster.primary_endpoint_address
     member_clusters          = jsonencode(module.example_team_ec_cluster.member_clusters)
     auth_token               = module.example_team_ec_cluster.auth_token
+    access_key_id     = module.example_team_ec_cluster.access_key_id
+    secret_access_key = module.example_team_ec_cluster.secret_access_key
+    replication_group_id = module.example_team_ec_cluster.replication_group_id
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,15 @@ data "aws_iam_policy_document" "policy" {
       aws_elasticache_replication_group.ec_redis.arn,
     ]
   }
+  statement {
+    actions = [
+        "elasticache:DescribeCacheClusters",
+    ]
+
+    resources = [
+      aws_elasticache_replication_group.ec_redis.member_clusters,
+    ]
+  }
 
 }
 

--- a/main.tf
+++ b/main.tf
@@ -121,21 +121,15 @@ data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
         "elasticache:ModifyReplicationGroup",
+        "elasticache:DescribeReplicationGroups",
+         "elasticache:DescribeCacheClusters",
+
     ]
 
     resources = [
       aws_elasticache_replication_group.ec_redis.arn,
+      "arn:aws:elasticache:eu-west-2:754256621582:cluster:${aws_elasticache_replication_group.ec_redis.id}-*",
     ]
   }
-  statement {
-    actions = [
-        "elasticache:DescribeCacheClusters",
-    ]
-
-    resources = [
-      aws_elasticache_replication_group.ec_redis.member_clusters,
-    ]
-  }
-
 }
 

--- a/main.tf
+++ b/main.tf
@@ -100,3 +100,33 @@ resource "aws_elasticache_subnet_group" "ec_subnet" {
   name       = "ec-sg-${random_id.id.hex}"
   subnet_ids = data.aws_subnets.private.ids
 }
+
+
+resource "aws_iam_user" "user" {
+  name = "cp-elasticache-${random_id.id.hex}"
+  path = "/system/elasticache-user/"
+}
+
+resource "aws_iam_access_key" "key" {
+  user = aws_iam_user.user.name
+}
+
+resource "aws_iam_user_policy" "userpol" {
+  name   = aws_iam_user.user.name
+  policy = data.aws_iam_policy_document.policy.json
+  user   = aws_iam_user.user.name
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    actions = [
+        "elasticache:ModifyReplicationGroup",
+    ]
+
+    resources = [
+      aws_elasticache_replication_group.ec_redis.arn,
+    ]
+  }
+
+}
+

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,12 @@ resource "random_id" "id" {
 
 resource "random_id" "auth_token" {
   byte_length = 32
+  keepers = local.auth_token_rotation_seed
 }
 
+locals {
+  auth_token_rotation_seed = var.auth_token_rotated_date == "" ? {} : { "auth-token-rotated-date" = var.auth_token_rotated_date }
+}
 data "aws_vpc" "selected" {
   filter {
     name   = "tag:Name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,8 @@ output "secret_access_key" {
   description = "Secret key for elasticache"
   value       = aws_iam_access_key.key.secret
 }
+
+output "replication_group_id" {
+  value       = aws_elasticache_replication_group.ec_redis.replication_group_id
+  description = "Redis cluster ID"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,14 @@ output "auth_token" {
   description = "The password used to access the Redis protected server."
   value       = aws_elasticache_replication_group.ec_redis.auth_token
 }
+
+
+output "access_key_id" {
+  description = "Access key id for elasticache"
+  value       = aws_iam_access_key.key.id
+}
+
+output "secret_access_key" {
+  description = "Secret key for elasticache"
+  value       = aws_iam_access_key.key.secret
+}

--- a/variables.tf
+++ b/variables.tf
@@ -75,3 +75,9 @@ variable "maintenance_window" {
   description = "Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`."
   default     = ""
 }
+
+variable "auth_token_rotated_date" {
+  type        = string
+  default     = ""
+  description = "Process to spin new auth token. Pass date to regenerate new token"
+}


### PR DESCRIPTION
- allow user to pass auth_token_rotated_date which will re-generate the auth_token and update the elasticache.
- Create iam user with permissions to describe cache and modify replication group to set the rotated AUTH_TOKEN

