### PR TITLE
Update aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,13 @@ ruby -r redis -e 'redis = Redis.new(uri: ENV.fetch("REDIS_URL")); redis.set("foo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0, < 5.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0, < 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_security_group" "ec" {
 ##############################
 resource "aws_elasticache_replication_group" "ec_redis" {
   automatic_failover_enabled = true
-  availability_zones = slice(
+  preferred_cache_cluster_azs = slice(
     data.aws_availability_zones.available.names,
     0,
     var.number_cache_clusters,

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This PR updates the availability zone syntax for `aws_elasticache_replication_group` for provider bump.

relates to. https://github.com/ministryofjustice/cloud-platform/issues/6517

