### PR TITLE
Add preferred_cache_cluster_azs variable to allow AZ selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ No modules.
 | <a name="input_node_type"></a> [node\_type](#input\_node\_type) | Instance class to be used | `string` | n/a | yes |
 | <a name="input_number_cache_clusters"></a> [number\_cache\_clusters](#input\_number\_cache\_clusters) | Number of cache clusters (primary and replicas) this replication group will have | `string` | `"2"` | no |
 | <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the parameter group aligned with the version specified in engine\_version (e.g. default.redis7) | `string` | n/a | yes |
+| <a name="input_preferred_cache_cluster_azs"></a> [preferred\_cache\_cluster\_azs](#input\_preferred\_cache\_cluster\_azs) | List of EC2 availability zones in which the cache clusters will be created. If not specified, AZs are chosen automatically based on number\_cache\_clusters. | `list(string)` | `[]` | no |
 | <a name="input_snapshot_window"></a> [snapshot\_window](#input\_snapshot\_window) | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period. Example: 05:00-09:00 | `string` | `""` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Team name | `string` | n/a | yes |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | The name of the vpc (eg.: live-1) | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_security_group" "ec" {
 ##############################
 resource "aws_elasticache_replication_group" "ec_redis" {
   automatic_failover_enabled = true
-  preferred_cache_cluster_azs = slice(
+  preferred_cache_cluster_azs = length(var.preferred_cache_cluster_azs) > 0 ? var.preferred_cache_cluster_azs : slice(
     data.aws_availability_zones.available.names,
     0,
     var.number_cache_clusters,

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "number_cache_clusters" {
   default     = "2"
 }
 
+variable "preferred_cache_cluster_azs" {
+  description = "List of EC2 availability zones in which the cache clusters will be created. If not specified, AZs are chosen automatically based on number_cache_clusters."
+  type        = list(string)
+  default     = []
+}
+
 variable "snapshot_window" {
   type        = string
   description = "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period. Example: 05:00-09:00"


### PR DESCRIPTION
This feature is meant to enable users select their AZs of choice especially giving AWS tends to run out of cluster capacity in AZs in the eu-west-2 region, particularly the eu-west-2b AZ.

### What this fixes
- In the event that an AZ runs out of capacity in the eu-west-2 region (which has become a recurrent event lately), users are able to switch to AZs with available capacity and are unblocked
- This provides flexibility and ensures cluster creations are uninterrupted unless either multiple AZs or the entire region are out of capacity

### Test outcome
This has been successfully tested in [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/40951). Also confirm in this [section of the deployment in the pipeline](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-live/jobs/apply-namespace-changes-live/builds/20100#L693e2b10:732) and the image attached.
<img width="1347" height="905" alt="Screenshot 2026-03-23 at 11 58 02" src="https://github.com/user-attachments/assets/75652297-cae2-47fc-8bf6-5011aa60ae6a" />


Relates to https://github.com/ministryofjustice/cloud-platform/issues/8094